### PR TITLE
Update registry name, and tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Learn Private Module Registry
+# Share Modules in the Private Registry
 
-The companion repository for the [Learn guide](https://learn.hashicorp.com/terraform/modules/private-modules) on using the private module registry in Terraform Cloud.
+The companion repository for the [Learn tutorial](https://learn.hashicorp.com/tutorials/terraform/module-private-registry-share) on using the private registry in Terraform Cloud.

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,3 @@
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.0.0"
-    }
-  }
-}
-
-provider "aws" {
-  region = var.region
-}
-
 resource "aws_s3_bucket" "bucket" {
   bucket = "${var.prefix}-${var.name}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket = "${var.prefix}-${var.name}"
+  bucket_prefix = "${var.prefix}-${var.name}"
 
   force_destroy = true
 }


### PR DESCRIPTION
TFC's "module registry" is now just "registry". Also, the tutorial link has changed, so use new link.