### PR TITLE
Update output value for s3 website endpoint

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "endpoint" {
-  value = aws_s3_bucket.bucket.website_endpoint
+  #value = aws_s3_bucket.bucket.website_endpoint
+  value = aws_s3_bucket_website_configuration.bucket.website_endpoint
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,3 @@
 output "endpoint" {
-  #value = aws_s3_bucket.bucket.website_endpoint
   value = aws_s3_bucket_website_configuration.bucket.website_endpoint
 }


### PR DESCRIPTION
`aws_s3_bucket.bucket.website_endpoint` is supposedly deprecated, reflected in my plan output 
![image](https://user-images.githubusercontent.com/21957580/187354450-7ded94ae-5fe8-4235-9340-a82bc08d87ba.png) There would not be any endpoint value in the output after a successful apply.

After updating it to `aws_s3_bucket_website_configuration.bucket.website_endpoint` the website endpoint output is successfully shown post-apply. 